### PR TITLE
Fix handling of dev versions

### DIFF
--- a/pyreq2rpm/pyreq2rpm.py
+++ b/pyreq2rpm/pyreq2rpm.py
@@ -56,7 +56,7 @@ class RpmVersion():
         if self.pre:
             rpm_suffix = '~{}'.format(''.join(str(x) for x in self.pre))
         elif self.dev:
-            rpm_suffix = '~{}'.format(''.join(str(x) for x in self.dev))
+            rpm_suffix = '~~{}'.format(''.join(str(x) for x in self.dev))
         elif self.post:
             rpm_suffix = '^post{}'.format(self.post[1])
         else:

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -106,6 +106,9 @@ def run_rpmbuild(dep):
     (['foobar', '>', '2.4.8.post1'], 'foobar > 2.4.8^post1'),
     (['foobar', '>', '2.0.post1'], 'foobar > 2^post1'),
     (['foobar', '>', '0.0'], 'foobar > 0'),
+    (['foobar', '>', '1.0.0.dev4'], 'foobar > 1~~dev4'),
+    (['foobar', '>', '1.1.1a2'], 'foobar > 1.1.1~a2'),
+    (['foobar', '>', '1.1.0rc3'], 'foobar > 1.1~rc3'),
 ])
 def test_convert(arg, expected):
     assert convert(*arg) == expected

--- a/tests/test_requirement.py
+++ b/tests/test_requirement.py
@@ -768,6 +768,14 @@ import pkg_resources
     ('2', 'foobar > 2.0.post1', False),
     ('2.0.0b5', 'foobar > 2.0.post1', False),
     ('2.0.post1', 'foobar > 2.0.post1', False),
+    ('1.dev1', 'foobar > 1a1', False),
+    ('1a1', 'foobar > 1.dev1', True),
+    ('1a1', 'foobar > 1b1', False),
+    ('1b1', 'foobar > 1a1', True),
+    ('1b1', 'foobar > 1rc1', False),
+    ('1', 'foobar > 1rc1', True),
+    ('1', 'foobar > 1.post1', False),
+    ('1.post1', 'foobar > 1', False),
 ])
 def test_requirement(version, arg, expected):
     assert (version in pkg_resources.Requirement.parse(arg)) == expected


### PR DESCRIPTION
And add tests

    $ rpmdev-vercmp 11~dev1 11~a1
    11~dev1 > 11~a1
    $ rpmdev-vercmp 11~~dev1 11~a1
    11~~dev1 < 11~a1
