### PR TITLE
Fix a regression with required legacy versions (e.g. pytz>dev)

### DIFF
--- a/pyreq2rpm/pyreq2rpm.py
+++ b/pyreq2rpm/pyreq2rpm.py
@@ -125,12 +125,16 @@ def convert_ordered(name, operator, version_id):
             operator = '<'
     else:
         version = RpmVersion(version_id)
-    # Prevent dev and pre-releases from satisfying a < requirement
-    if operator == '<' and not version.pre and not version.dev and not version.post:
-        version = '{}~~'.format(version)
-    # Prevent post-releases from satisfying a > requirement
-    if operator == '>' and not version.pre and not version.dev and not version.post:
-        version = '{}.0'.format(version)
+    # For backwards compatibility, fallback to previous behavior with LegacyVersions
+    try:
+        # Prevent dev and pre-releases from satisfying a < requirement
+        if operator == '<' and not version.pre and not version.dev and not version.post:
+            version = '{}~~'.format(version)
+        # Prevent post-releases from satisfying a > requirement
+        if operator == '>' and not version.pre and not version.dev and not version.post:
+            version = '{}.0'.format(version)
+    except AttributeError:
+        pass
     return '{} {} {}'.format(name, operator, version)
 
 OPERATORS = {'~=': convert_compatible,

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -109,6 +109,7 @@ def run_rpmbuild(dep):
     (['foobar', '>', '1.0.0.dev4'], 'foobar > 1~~dev4'),
     (['foobar', '>', '1.1.1a2'], 'foobar > 1.1.1~a2'),
     (['foobar', '>', '1.1.0rc3'], 'foobar > 1.1~rc3'),
+    (['foobar', '>', 'dev'], 'foobar > dev'), # see https://bugzilla.redhat.com/2019954
 ])
 def test_convert(arg, expected):
     assert convert(*arg) == expected


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2019954